### PR TITLE
Count offline subscriptions in QlobberSub

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "aedes-packet": "^1.0.0",
     "from2": "^2.1.0",
-    "qlobber": "^1.6.0",
+    "qlobber": "^1.8.0",
     "safe-buffer": "^5.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "aedes-packet": "^1.0.0",
     "from2": "^2.1.0",
-    "qlobber": "^1.5.0",
+    "qlobber": "^1.6.0",
     "safe-buffer": "^5.0.1"
   }
 }

--- a/persistence.js
+++ b/persistence.js
@@ -141,7 +141,7 @@ MemoryPersistence.prototype.subscriptionsByClient = function (client, cb) {
 }
 
 MemoryPersistence.prototype.countOffline = function (cb) {
-  return cb(null, this._trie.sub_count, this._clientsCount)
+  return cb(null, this._trie.subscriptionsCount, this._clientsCount)
 }
 
 MemoryPersistence.prototype.subscriptionsByTopic = function (pattern, cb) {


### PR DESCRIPTION
It's easy for [QlobberSub](https://github.com/davedoesdev/qlobber/blob/master/aedes/qlobber-sub.js) to do and is O(1). Makes negligible different to the [aedes bench](https://github.com/davedoesdev/qlobber/blob/master/aedes/bench/sub.js) results. 

[Tested](https://github.com/davedoesdev/qlobber/blob/master/test/aedes.js) to 100% coverage of QlobberSub.

This is useful for aedes-persistence-redis so it doesn't have to jump through hoops to maintain an offline subscription count (which it actually fails to do correctly at the moment).