### PR TITLE
Allow callback for non-publish packet in outgoingUpdate

### DIFF
--- a/abstract.js
+++ b/abstract.js
@@ -1116,8 +1116,10 @@ function abstractPersistence (opts) {
             var stream = instance.outgoingStream(client)
             stream.pipe(concat(function (list) {
               t.equal(list.length, 2, 'must have two items in queue')
-              t.deepEqual(list[0].brokerCounter, packet1.brokerCounter, 'packet must match')
-              t.deepEqual(list[1].brokerCounter, packet2.brokerCounter, 'packet must match')
+              t.equal(list[0].brokerCounter, packet1.brokerCounter, 'brokerCounter must match')
+              t.equal(list[0].messageId, packet1.messageId, 'messageId must match')
+              t.equal(list[1].brokerCounter, packet2.brokerCounter, 'brokerCounter must match')
+              t.equal(list[1].messageId, packet2.messageId, 'messageId must match')
               instance.destroy(t.end.bind(t))
             }))
           })

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "faucet": "0.0.1",
     "mqemitter": "^3.0.0",
     "pre-commit": "^1.2.2",
+    "pump": "^3.0.0",
     "standard": "^13.0.2",
     "tape": "^4.11.0",
     "through2": "^3.0.1"

--- a/persistence.js
+++ b/persistence.js
@@ -201,15 +201,21 @@ MemoryPersistence.prototype.outgoingUpdate = function (client, packet, cb) {
 
   for (i = 0; i < outgoing.length; i++) {
     temp = outgoing[i]
-    if (temp.brokerId === packet.brokerId &&
-      temp.brokerCounter === packet.brokerCounter) {
+    if (temp.brokerId === packet.brokerId) {
+      if (temp.brokerCounter === packet.brokerCounter) {
       temp.messageId = packet.messageId
       return cb(null, client, packet)
-    } else if (temp.messageId === packet.messageId) {
-      if (packet.cmd !== 'publish') {
-      // for non-PUBLISH packet only
-        outgoing[i] = packet
       }
+      /*
+      Maximum of messageId (packet identifier) is 65535 and will be rotated,
+      brokerCounter is to ensure the packet identifier be unique.
+      The for loop is going to search which packet messageId should be updated
+      in the _outgoing queue.
+      If there is a case that brokerCounter is different but messageId is same,
+      we need to let the loop keep searching
+      */
+    } else if (temp.messageId === packet.messageId) {
+        outgoing[i] = packet
       return cb(null, client, packet)
     }
   }

--- a/persistence.js
+++ b/persistence.js
@@ -208,7 +208,7 @@ MemoryPersistence.prototype.outgoingUpdate = function (client, packet, cb) {
     } else if (temp.messageId === packet.messageId) {
       if (packet.cmd !== 'publish') {
       // for non-PUBLISH packet only
-      outgoing[i] = packet
+        outgoing[i] = packet
       }
       return cb(null, client, packet)
     }

--- a/persistence.js
+++ b/persistence.js
@@ -203,8 +203,8 @@ MemoryPersistence.prototype.outgoingUpdate = function (client, packet, cb) {
     temp = outgoing[i]
     if (temp.brokerId === packet.brokerId) {
       if (temp.brokerCounter === packet.brokerCounter) {
-      temp.messageId = packet.messageId
-      return cb(null, client, packet)
+        temp.messageId = packet.messageId
+        return cb(null, client, packet)
       }
       /*
       Maximum of messageId (packet identifier) is 65535 and will be rotated,
@@ -215,7 +215,7 @@ MemoryPersistence.prototype.outgoingUpdate = function (client, packet, cb) {
       we need to let the loop keep searching
       */
     } else if (temp.messageId === packet.messageId) {
-        outgoing[i] = packet
+      outgoing[i] = packet
       return cb(null, client, packet)
     }
   }

--- a/persistence.js
+++ b/persistence.js
@@ -205,9 +205,11 @@ MemoryPersistence.prototype.outgoingUpdate = function (client, packet, cb) {
       temp.brokerCounter === packet.brokerCounter) {
       temp.messageId = packet.messageId
       return cb(null, client, packet)
-    } else if (packet.cmd !== 'publish' && temp.messageId === packet.messageId) {
+    } else if (temp.messageId === packet.messageId) {
+      if (packet.cmd !== 'publish') {
       // for non-PUBLISH packet only
       outgoing[i] = packet
+      }
       return cb(null, client, packet)
     }
   }


### PR DESCRIPTION
The callback like `emptyQueueFilter` in https://github.com/mcollina/aedes/blob/master/lib/handlers/connect.js#L178, and this will not fail the unit test in https://github.com/mcollina/aedes/blob/master/test/client-pub-sub.js#L114