### PR TITLE
Fixing failing tests with aedes-persistence-mongodb

### DIFF
--- a/abstract.js
+++ b/abstract.js
@@ -882,8 +882,8 @@ function abstractPersistence (opts) {
           instance.outgoingUpdate(client, data,
             function (_, client, packet) {
               queue.push(packet)
+              next()
             })
-          next()
         }), function done () {
           t.equal(queue.length, 2)
           if (queue.length === 2) {

--- a/abstract.js
+++ b/abstract.js
@@ -779,7 +779,6 @@ function abstractPersistence (opts) {
 
       stream.pipe(concat(function (list) {
         var packet = list[0]
-        t.ok(Object.prototype.hasOwnProperty.call(packet, 'messageId'))
         t.equal(packet.messageId, undefined, 'should have an unassigned messageId in queue')
         delete packet.messageId
         t.deepEqual(packet, expected, 'must return the packet')
@@ -832,7 +831,6 @@ function abstractPersistence (opts) {
       var stream = instance.outgoingStream(client)
       stream.pipe(concat(function (list) {
         var packet = list[0]
-        t.ok(Object.prototype.hasOwnProperty.call(packet, 'messageId'))
         t.equal(packet.messageId, undefined, 'should have an unassigned messageId in queue')
         delete packet.messageId
         t.deepEqual(packet, expected, 'must return the packet')
@@ -840,7 +838,6 @@ function abstractPersistence (opts) {
         var stream2 = instance.outgoingStream(client2)
         stream2.pipe(concat(function (list) {
           var packet = list[0]
-          t.ok(Object.prototype.hasOwnProperty.call(packet, 'messageId'))
           t.equal(packet.messageId, undefined, 'should have an unassigned messageId in queue')
           delete packet.messageId
           t.deepEqual(packet, expected, 'must return the packet')
@@ -935,7 +932,6 @@ function abstractPersistence (opts) {
 
       stream.pipe(concat(function (list) {
         var packet = list[0]
-        t.ok(Object.prototype.hasOwnProperty.call(packet, 'messageId'))
         t.equal(packet.messageId, undefined, 'should have an unassigned messageId in queue')
         delete packet.messageId
         t.deepEqual(packet, expected, 'must return the packet')
@@ -981,7 +977,6 @@ function abstractPersistence (opts) {
 
       stream.pipe(concat(function (list) {
         var packet = list[0]
-        t.ok(Object.prototype.hasOwnProperty.call(packet, 'messageId'))
         t.equal(packet.messageId, undefined, 'should have an unassigned messageId in queue')
         delete packet.messageId
         t.deepEqual(packet, expected, 'must return the packet')


### PR DESCRIPTION
When storing docs with mongodb, if a key has an undefined value that will be converted to null when stored and this makes test fails.

This PR paired with another on aedes-persistence-mongodb that deletes undefined messageIds before storing a doc will fix the tests.

There is still one test that is failing but I need your help:

```
⨯ add outgoing packet as a string and pump
  not ok 225 should be equal
    ---
      operator: equal
      expected: 2
      actual:   0
      at: done (/aedes-persistence/abstract.js:888:13)
```
     